### PR TITLE
Remove likes display

### DIFF
--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -31,15 +31,6 @@ function Post() {
           <p className='textarea'>
             Comment: {validator.unescape(comment.body)}
           </p>
-          <p>
-            {comment.likes === 0
-              ? '0 likes'
-              : comment.likes === 1
-              ? `1 like`
-              : `${comment.likes} likes`}
-            <button>Like</button>
-            <button>Delete</button>
-          </p>
         </div>
       ))}
       <br />


### PR DESCRIPTION
This PR:
- Removes code that would display/accept input for liking posts/comments and reporting comments

Because:
* Likes and reporting are extra features, and not needed for the project, falling into the 'no-go' zone.
